### PR TITLE
Fix processor in burpyServicePyro3

### DIFF
--- a/res/burpyServicePyro3.py
+++ b/res/burpyServicePyro3.py
@@ -91,14 +91,15 @@ class BridaServicePyro:
         return self.method_list
 
     def invoke_method(self,method_name, data):
-        data = http(b64d(data))
-        data.headers.update({"first_line":data.first_line})
         func = getattr(self.burpy, method_name)
         if data is None:
             return "Parse HTTP data failed"
         try:
             # headers is dict, body is str
             if func.__name__ != "processor":
+                #fix processor bug
+                data = http(b64d(data))
+                data.headers.update({"first_line":data.first_line}) 
                 data.headers, data.body = func(data.headers, data.body)
                 ret_val = data.build()
             else:


### PR DESCRIPTION
原来的代码中，processPayload 和 processHttpMessageprocessor 中invoke processor 传入的数据不同，processPayload传入的是原生payload，processHttpMessageprocessor传入的是进过base64编码的报文，invoke_method在调用函数判断之前直接进行base64解码并转换为http object，会导致processPayload失效。

process函数应该是用作Intruder中payload处理的，所以将base64解密及类型转换的过程放到了非processor分支中。