### PR TITLE
可拉伸的显示文本对话框 fix #15

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -27,6 +27,7 @@ import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
 
+import burp.ui.MessageDialog;
 import org.apache.commons.lang3.ArrayUtils;
 import org.fife.ui.rsyntaxtextarea.FileLocation;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -107,6 +108,7 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 
 	public List<String> burpyMethods;
 
+	@Override
 	public void registerExtenderCallbacks(IBurpExtenderCallbacks c) {
 
 		// Keep a reference to our callbacks object
@@ -639,11 +641,13 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 
 	}
 
+	@Override
 	public String getTabCaption() {
 
 		return "Burpy";
 	}
 
+	@Override
 	public Component getUiComponent() {
 		return mainPanel;
 	}
@@ -660,6 +664,7 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 
 
 
+	@Override
 	public void actionPerformed(ActionEvent event) {
 
 		String command = event.getActionCommand();
@@ -778,13 +783,7 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 						
 						@Override
 						public void run() {
-							JTextArea ta = new JTextArea(20, 60);
-							ta.setLineWrap(true);
-							ta.setText(msg);
-							ta.setWrapStyleWord(true);
-							ta.setCaretPosition(0);
-							ta.setEditable(false);
-							JOptionPane.showMessageDialog(null, new JScrollPane(ta), "Burpy "+command, JOptionPane.INFORMATION_MESSAGE);
+							MessageDialog.show("Burpy "+command, msg);
 						}
 					});
 				}
@@ -909,6 +908,7 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 
 	}
 
+	@Override
 	public List<JMenuItem> createMenuItems(IContextMenuInvocation invocation) {
 
 			currentInvocation = invocation;
@@ -1157,6 +1157,7 @@ public class BurpExtender implements IBurpExtender, ITab, ActionListener, IConte
 		return ret;
 	}
 
+	@Override
 	public void processHttpMessage(int toolFlag, boolean messageIsRequest, IHttpRequestResponse messageInfo) {
 		List<String> headers = null;
 		String pyroUrl = "PYRO:BridaServicePyro@" + pyroHost.getText() +":" + pyroPort.getText();

--- a/src/main/java/burp/ui/MessageDialog.java
+++ b/src/main/java/burp/ui/MessageDialog.java
@@ -1,0 +1,80 @@
+package burp.ui;
+
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rtextarea.RTextScrollPane;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * @author ViCrack
+ *
+ * 显示文本的对话框, 支持缩放拉伸, 鼠标右键菜单显示
+ *
+ * TODO 鼠标滚轮可缩放字体, 支持切换编辑器语法高亮, 切换换行
+ */
+public class MessageDialog extends JDialog {
+
+    private final RSyntaxTextArea syntaxTextArea = new RSyntaxTextArea();
+    private final String title;
+    private final String msg;
+
+    public MessageDialog(String title, String msg) {
+        this.title = title;
+        this.msg = msg;
+        init();
+    }
+
+    private void init() {
+        setTitle(title);
+        getContentPane().setLayout(new BorderLayout());
+        RTextScrollPane scrollPane = new RTextScrollPane(syntaxTextArea);
+
+        syntaxTextArea.setText(msg);
+        syntaxTextArea.setLineWrap(false);
+        syntaxTextArea.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        syntaxTextArea.setCaretPosition(0);
+        // 设置语法高亮
+        //syntaxTextArea.setSyntaxEditingStyle();
+
+        JPanel southPanel = new JPanel();
+        JButton btnClose = new JButton();
+        btnClose.setText("Close");
+        btnClose.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        });
+        FlowLayout flowLayout1 = new FlowLayout();
+        southPanel.setLayout(flowLayout1);
+        flowLayout1.setAlignment(FlowLayout.RIGHT);
+        getContentPane().add(southPanel, BorderLayout.SOUTH);
+        southPanel.add(btnClose);
+        getContentPane().add(scrollPane, BorderLayout.CENTER);
+        scrollPane.setViewportView(syntaxTextArea);
+
+        Dimension screensize = Toolkit.getDefaultToolkit().getScreenSize();
+        int width = (int)screensize.getWidth();
+        int height = (int)screensize.getHeight();
+        setSize(width / 3,  height / 3);
+
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        setAlwaysOnTop(true);
+        setVisible(true);
+
+    }
+
+    /**
+     * 显示文本窗口
+     * @param title 对话框标题
+     * @param msg   对话框的内容
+     */
+    public static void show(String title, String msg){
+        new MessageDialog(title, msg);
+    }
+
+}


### PR DESCRIPTION
- [X] 窗口支持自由缩放拉伸, 支持鼠标右键菜单显示等


- [ ] 支持切换编辑器语法高亮
- [ ] 切换换行

![图片](https://user-images.githubusercontent.com/18179821/103293997-ea4e9600-4a2b-11eb-8c9e-1afb74ded8aa.png)
